### PR TITLE
Add superuser creation and update Docker configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ docker compose up --build
 
 ## What Docker Includes
 - API Server (http://localhost:8000)
+- API Admin Panel (http://localhost:8000/admin)
 - Flower For Celery (http://localhost:5555)
 - Redis (http://localhost:6379)
 - PostgreSQL (http://localhost:5432)
 - Nginx (http://localhost:80)
+
+Admin Panel Credentials:
+- Username: root
+- Password: root
 
 ## Stopping the Project
 When you're done working, you can stop your containers with this command:

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,10 @@ services:
     restart: always
     build:
       context: .
+    environment:
+      DJANGO_SUPERUSER_PASSWORD: "root"
+      DJANGO_SUPERUSER_USERNAME: "root"
+      DJANGO_SUPERUSER_EMAIL: "root@root.com"
     volumes:
       - .:/app
       - static:/app/static
@@ -29,6 +33,8 @@ services:
     volumes:
       - .:/app
     depends_on:
+      server:
+        condition: service_started
       database:
         condition: service_started
       redis:
@@ -53,6 +59,8 @@ services:
       redis:
         condition: service_started
       celery_worker:
+        condition: service_started
+      server:
         condition: service_started
 
   database:

--- a/entrypoints/celery-flower-entrypoint.sh
+++ b/entrypoints/celery-flower-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 echo "Starting celery Flower..."
-
 celery -A sport_connect_api.celery flower --port=5555 --persisten=True

--- a/entrypoints/celery-worker-entrypoint.sh
+++ b/entrypoints/celery-worker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 echo "Starting celery worker..."
-
 celery -A sport_connect_api.celery worker --loglevel=DEBUG -P gevent -E -c 1000

--- a/entrypoints/docker-entrypoint.sh
+++ b/entrypoints/docker-entrypoint.sh
@@ -6,10 +6,13 @@ python manage.py collectstatic --noinput
 echo "Migrate..."
 python manage.py migrate --noinput
 
+echo "Create superuser..."
+python manage.py createsuperuser --noinput
+
 echo "Load fixtures..."
 python -Xutf8 manage.py loaddata ./fixtures/core.json
 
 echo "Starting server..."
-gunicorn 'sport_connect_api.wsgi' --bind=0.0.0.0:8000
+gunicorn 'sport_connect_api.wsgi' --reload --bind=0.0.0.0:8000
 
 ENTRYPOINT ["/app/entrypoints/docker-entrypoint.sh"]


### PR DESCRIPTION
Superuser creation has been added to the Docker entrypoint script. Docker configurations have been updated with this, including adding environment variables for superuser credentials and updating dependencies in compose.yml. Removal of extra newline in the Celery entrypoint scripts has also been done. Changes are also reflected in the README, with API admin panel and credentials info added.