### PR TITLE
Update container names for nginx and certbot in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -95,7 +95,7 @@ services:
       - redis_data:/var/lib/redis
 
   nginx:
-    container_name: nginx
+    container_name: nginx-api
     image: nginx:latest
     restart: always
     ports:
@@ -113,7 +113,7 @@ services:
         condition: service_started
 
   certbot:
-    container_name: certbot
+    container_name: certbot-api
     image: certbot/certbot
     depends_on:
       - nginx


### PR DESCRIPTION
The container names for the nginx and certbot services have been updated in the compose.yaml file. The previous names 'nginx' and 'certbot' have been changed to 'nginx-api' and 'certbot-api' respectively.