### PR TITLE
Update Dockerfile to provide executable permissions to entrypoint scr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,9 @@ COPY . .
 # Expose the port that the application listens on.
 EXPOSE 8000
 
+RUN chmod a+x /app/entrypoints/docker-entrypoint.sh
+RUN chmod a+x /app/entrypoints/celery-flower-entrypoint.sh
+RUN chmod a+x /app/entrypoints/celery-worker-entrypoint.sh
+
 # Run the application.
 ENTRYPOINT ["/app/entrypoints/docker-entrypoint.sh"]


### PR DESCRIPTION
…ipts

The commit adds execute permissions to 'docker-entrypoint.sh', 'celery-flower-entrypoint.sh', and 'celery-worker-entrypoint.sh' within the Dockerfile. These changes have been made using the `chmod a+x` command to ensure the proper functioning of these scripts when the Docker container is run.