### PR TITLE
Change database settings to use SQLite

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -42,6 +42,7 @@ class AverageValuesStandards(BaseModel):
                                        verbose_name="Стать дитини", null=True)
     average_value = models.FloatField(verbose_name="Середнє значення", null=True)
     sigma = models.FloatField(verbose_name="Сигма")
+    # average_range = models.(verbose_name="Діапазон середнього значення", null=True)
 
     def __str__(self):
         return self.name_standard

--- a/sport_connect_api/settings.py
+++ b/sport_connect_api/settings.py
@@ -127,16 +127,24 @@ CHANNEL_LAYERS = {
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.postgresql_psycopg2',
+#         'NAME': env.str('DATABASE_NAME'),
+#         'USER': env.str('DATABASE_USER'),
+#         'PASSWORD': env.str('DATABASE_PASSWORD'),
+#         'HOST': env.str('DATABASE_HOST'),
+#         'PORT': env.int('DATABASE_PORT')
+#     }
+# }
+
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': env.str('DATABASE_NAME'),
-        'USER': env.str('DATABASE_USER'),
-        'PASSWORD': env.str('DATABASE_PASSWORD'),
-        'HOST': env.str('DATABASE_HOST'),
-        'PORT': env.int('DATABASE_PORT')
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
+
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
The settings for the database have been changed from Postgresql to SQLite in the Django settings configuration. The decision is made to simplify initial setup for development, utilizing SQLite's ability to store data directly into a local file.