### PR TITLE
Set working directory in Django entrypoint script

### DIFF
--- a/entrypoints/django-entrypoint.sh
+++ b/entrypoints/django-entrypoint.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -o nounset
 
+cd /app
+
 echo "Migrate collect static..."
 python manage.py collectstatic --noinput &&
 


### PR DESCRIPTION
Updated the django-entrypoint.sh to start execution from "/app" directory. This adjustment ensures the correct context when running following Django tasks in the script, improving overall reliability.