### PR TITLE
Set working directory in Django entrypoint script

### DIFF
--- a/entrypoints/django-entrypoint.sh
+++ b/entrypoints/django-entrypoint.sh
@@ -3,17 +3,19 @@
 set -o errexit
 set -o nounset
 
+ls -l
+
 echo "Migrate collect static..."
-python /app/manage.py collectstatic --noinput &&
+python manage.py collectstatic --noinput &&
 
 echo "Migrate..."
-python /app/manage.py migrate --noinput &&
+python manage.py migrate --noinput &&
 
 echo "Create superuser..."
-python /app/manage.py createsuperuser --noinput &&
+python manage.py createsuperuser --noinput &&
 
 echo "Load fixtures..."
-python -Xutf8 /app/manage.py loaddata ./fixtures/core.json &&
+python -Xutf8 manage.py loaddata ./fixtures/core.json &&
 
 echo "Starting server..."
-gunicorn 'app.sport_connect_api.wsgi' --reload --bind=0.0.0.0:8000
+gunicorn 'sport_connect_api.wsgi' --reload --bind=0.0.0.0:8000


### PR DESCRIPTION
Updated the django-entrypoint.sh to start execution from "/app" directory. This adjustment ensures the correct context when running following Django tasks in the script, improving overall reliability.