### PR TITLE
Apply improvement to Docker-related files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=requirements.txt \
     python -m pip install -r requirements.txt
 
-# Copy the source code into the container.
-
 # Expose the port that the application listens on.
 EXPOSE 8000
 

--- a/entrypoints/django-entrypoint.sh
+++ b/entrypoints/django-entrypoint.sh
@@ -5,6 +5,10 @@ set -o nounset
 
 ls -l
 
+if [ "${IS_SERVER}" == "True" ]; then
+  cd sport-connect-api
+fi
+
 echo "Migrate collect static..."
 python manage.py collectstatic --noinput &&
 


### PR DESCRIPTION
Removed an unnecessary comment in Dockerfile and made an important adjustment in django-entrypoint.sh. The change sets the working directory of the server to 'sport-connect-api' when the 'IS_SERVER' variable is set to 'True', ensuring the correct context for subsequent tasks.