### PR TITLE
Remove PostgreSQL connection check from entrypoint.sh

### DIFF
--- a/entrypoints/django-entrypoint.sh
+++ b/entrypoints/django-entrypoint.sh
@@ -3,12 +3,6 @@
 set -o errexit
 set -o nounset
 
-ls -l
-
-if [ "${IS_SERVER}" == "True" ]; then
-  cd sport-connect-api
-fi
-
 echo "Migrate collect static..."
 python manage.py collectstatic --noinput &&
 

--- a/entrypoints/entrypoint.sh
+++ b/entrypoints/entrypoint.sh
@@ -7,31 +7,31 @@ set -o pipefail
 # exits if any of your variables is not set
 set -o nounset
 
-if [ "${IS_SERVER}" == "False" ]; then
-postgres_ready() {
-python << END
-  import sys
-
-  import psycopg2
-
-  try:
-      psycopg2.connect(
-          dbname="${DATABASE_NAME}",
-          user="${DATABASE_USER}",
-          password="${DATABASE_PASSWORD}",
-          host="${DATABASE_HOST}",
-          port="${DATABASE_PORT}",
-      )
-  except psycopg2.OperationalError:
-      sys.exit(-1)
-  sys.exit(0)
-END
-}
-until postgres_ready; do
-  >&2 echo 'Waiting for PostgreSQL to become available...'
-  sleep 1
-done
->&2 echo 'PostgreSQL is available'
-fi
+#if [ "${IS_SERVER}" == "False" ]; then
+#postgres_ready() {
+#python << END
+#  import sys
+#
+#  import psycopg2
+#
+#  try:
+#      psycopg2.connect(
+#          dbname="${DATABASE_NAME}",
+#          user="${DATABASE_USER}",
+#          password="${DATABASE_PASSWORD}",
+#          host="${DATABASE_HOST}",
+#          port="${DATABASE_PORT}",
+#      )
+#  except psycopg2.OperationalError:
+#      sys.exit(-1)
+#  sys.exit(0)
+#END
+#}
+#until postgres_ready; do
+#  >&2 echo 'Waiting for PostgreSQL to become available...'
+#  sleep 1
+#done
+#>&2 echo 'PostgreSQL is available'
+#fi
 
 exec "$@"


### PR DESCRIPTION
This commit comments out the PostgreSQL connection check routine from entrypoint.sh. Additionally, directory context setup based on 'IS_SERVER' variable from django-entrypoint.sh has been removed. These changes simplify the docker entry point scripts and remove obsolete checks and actions that do not align with recent modifications to the docker setup.