### PR TITLE
Disable nginx and certbot services in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -80,32 +80,32 @@ services:
     volumes:
       - redis_data:/var/lib/redis
 
-  nginx:
-    container_name: nginx-api
-    image: nginx:latest
-    restart: always
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - .:/app
-      - static:/app/static
-      - media:/app/media
-      - ./nginx-conf.d:/etc/nginx/conf.d
-      - ./certbot/conf:/etc/letsencrypt
-      - ./certbot/www:/var/www/certbot
-    depends_on:
-      - server
-
-  certbot:
-    container_name: certbot-api
-    image: certbot/certbot
-    depends_on:
-      - nginx
-    volumes:
-      - ./nginx-conf.d:/etc/nginx/conf.d
-      - ./certbot/conf:/etc/letsencrypt
-      - ./certbot/www:/var/www/certbot
+#  nginx:
+#    container_name: nginx-api
+#    image: nginx:latest
+#    restart: always
+#    ports:
+#      - "80:80"
+#      - "443:443"
+#    volumes:
+#      - .:/app
+#      - static:/app/static
+#      - media:/app/media
+#      - ./nginx-conf.d:/etc/nginx/conf.d
+#      - ./certbot/conf:/etc/letsencrypt
+#      - ./certbot/www:/var/www/certbot
+#    depends_on:
+#      - server
+#
+#  certbot:
+#    container_name: certbot-api
+#    image: certbot/certbot
+#    depends_on:
+#      - nginx
+#    volumes:
+#      - ./nginx-conf.d:/etc/nginx/conf.d
+#      - ./certbot/conf:/etc/letsencrypt
+#      - ./certbot/www:/var/www/certbot
 
 volumes:
   static:


### PR DESCRIPTION
In this commit, the nginx and the certbot services have been commented out, removing them from the active configuration in the compose.yaml file. These changes suggest that they are either no longer used or currently not needed, which could simplify deployment and reduce resource allocation.