### PR TITLE
Remove database dependency from compose-prod.yaml

### DIFF
--- a/compose-prod.yaml
+++ b/compose-prod.yaml
@@ -56,7 +56,6 @@ services:
       - "5557:5555"
     depends_on:
       - redis
-      - database
 
   redis:
     image: redis:latest


### PR DESCRIPTION
The dependency of the database has been removed in the compose-prod.yaml file. This was done under the section where the application's services are declared. Consequently, the behaviour of how our services are orchestrated in production will be affected.