### PR TITLE
Add secure proxy SSL header to settings

### DIFF
--- a/sport_connect_api/settings.py
+++ b/sport_connect_api/settings.py
@@ -50,6 +50,7 @@ DEBUG = env.bool('DEBUG', default=True)
 
 ALLOWED_HOSTS = env.list('DJANGO_ALLOWED_HOSTS')
 CSRF_TRUSTED_ORIGINS = ['https://' + domain for domain in env.list('DJANGO_ALLOWED_HOSTS')]
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 # CORS Settings
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
The settings file has been updated to include a secure proxy SSL header. This addition increases the security of the application by ensuring that only HTTPS requests are forwarded from the proxy server.