### PR TITLE
Disable timezone usage in settings

### DIFF
--- a/sport_connect_api/settings.py
+++ b/sport_connect_api/settings.py
@@ -173,7 +173,7 @@ TIME_ZONE = 'Europe/Kiev'
 
 USE_I18N = True
 
-USE_TZ = True
+USE_TZ = False
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/


### PR DESCRIPTION
The USE_TZ setting in the sport_connect_api settings has been switched from True to False. This adjustment is critical for the correct functioning of the local time display, particularly for users based in Kiev.